### PR TITLE
added note describing bug in quickstart tutorial

### DIFF
--- a/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
+++ b/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.rst
@@ -140,6 +140,9 @@ Step 4: Use Motion Planning with the Panda
 * In the **MotionPlanning** window under the **Planning** tab, press the **Plan** button. You
   should be able to see a visualization of the arm moving and a trail.
 
+.. note::
+  Currently, the start state is ignored when following these steps. The planner instead starts from the current robot state. Changing the 'Start State:' drop-down in the Query box of the Planning tab can change this, but the behavior of that interface is also confusing.
+
 .. image:: rviz_plugin_planned_path.png
    :width: 700px
 


### PR DESCRIPTION
The actual behavior when following the quickstart tutorial doesn't match the description. The planner ignores the start state provided in the interactive interface, and instead plans from the current (simulated) machine state. This change is just a note describing the observed behavior.